### PR TITLE
Add Helm chart for Google Filestore PV and PVC

### DIFF
--- a/charts/filestore-pv-pvc/Chart.yaml
+++ b/charts/filestore-pv-pvc/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: filestore-pv-pvc
+description: Helm chart for provisioning a PersistentVolume and PersistentVolumeClaim backed by Google Cloud Filestore.
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/filestore-pv-pvc/README.md
+++ b/charts/filestore-pv-pvc/README.md
@@ -1,0 +1,23 @@
+# Filestore PV/PVC Helm Chart
+
+This chart provisions a PersistentVolume and matching PersistentVolumeClaim backed by a Google Cloud Filestore instance.
+
+## Values
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `storage.size` | Requested storage size for the PV/PVC | `1Ti` |
+| `storage.storageClassName` | StorageClass to associate with the PV/PVC | `standard-rwx` |
+| `storage.reclaimPolicy` | Reclaim policy for the PV | `Retain` |
+| `nfs.server` | IP address of the Filestore instance | `10.0.0.2` |
+| `nfs.path` | Export path on the Filestore instance | `/volumes/myshare` |
+| `pvc.name` | Name of the PersistentVolumeClaim | `filestore-data` |
+| `pv.name` | Name of the PersistentVolume | `filestore-pv` |
+
+## Usage
+
+```
+helm install filestore charts/filestore-pv-pvc \
+  --set nfs.server="<FILESTORE_IP>" \
+  --set nfs.path="<FILESTORE_PATH>"
+```

--- a/charts/filestore-pv-pvc/templates/_helpers.tpl
+++ b/charts/filestore-pv-pvc/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "filestore-pv-pvc.name" -}}
+{{- .Chart.Name -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "filestore-pv-pvc.fullname" -}}
+{{- printf "%s" (include "filestore-pv-pvc.name" .) -}}
+{{- end -}}

--- a/charts/filestore-pv-pvc/templates/pv.yaml
+++ b/charts/filestore-pv-pvc/templates/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ default (printf "%s-pv" (include "filestore-pv-pvc.fullname" .)) .Values.pv.name }}
+spec:
+  capacity:
+    storage: {{ .Values.storage.size }}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: {{ .Values.storage.reclaimPolicy }}
+  storageClassName: {{ .Values.storage.storageClassName }}
+  nfs:
+    path: {{ .Values.nfs.path }}
+    server: {{ .Values.nfs.server }}

--- a/charts/filestore-pv-pvc/templates/pvc.yaml
+++ b/charts/filestore-pv-pvc/templates/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ default (printf "%s-pvc" (include "filestore-pv-pvc.fullname" .)) .Values.pvc.name }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.storage.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}
+  volumeName: {{ default (printf "%s-pv" (include "filestore-pv-pvc.fullname" .)) .Values.pv.name }}

--- a/charts/filestore-pv-pvc/values.yaml
+++ b/charts/filestore-pv-pvc/values.yaml
@@ -1,0 +1,11 @@
+storage:
+  size: 1Ti
+  storageClassName: standard-rwx
+  reclaimPolicy: Retain
+nfs:
+  server: 10.0.0.2
+  path: /volumes/myshare
+pvc:
+  name: filestore-data
+pv:
+  name: filestore-pv


### PR DESCRIPTION
## Summary
- add Helm chart to provision Google Cloud Filestore-backed PV and PVC
- document chart values and usage

## Testing
- `helm lint charts/filestore-pv-pvc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c068a3dc832eb7bc51cfe6514379